### PR TITLE
Bugfix: Added blog page link in navbar

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -17,7 +17,7 @@
             <li><a href="about.html" class="active">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="portfolio.html">Portfolio</a></li>
-            <li><a href="#">Blog</a></li>
+            <li><a href="blog.html" class="active">Blog</a></li>
             <li><a href="contact.html">Contact</a></li>
         </ul>
     </nav>

--- a/src/contact.html
+++ b/src/contact.html
@@ -17,7 +17,7 @@
             <li><a href="about.html" class="active">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="portfolio.html">Portfolio</a></li>
-            <li><a href="#">Blog</a></li>
+            <li><a href="blog.html" class="active">Blog</a></li>
             <li><a href="contact.html">Contact</a></li>
         </ul>
     </nav>

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
             <li><a href="about.html" class="active">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="portfolio.html">Portfolio</a></li>
-            <li><a href="#">Blog</a></li>
+            <li><a href="blog.html" class="active">Blog</a></li>
             <li><a href="contact.html">Contact</a></li>
         </ul>
     </nav>

--- a/src/portfolio.html
+++ b/src/portfolio.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,6 +8,7 @@
     <link rel="stylesheet" href="../styles/common.css">
     <link rel="stylesheet" href="../styles/portfolio.css">
 </head>
+
 <body>
     <nav class="navbar">
         <div class="nav-brand">TechVision</div>
@@ -15,7 +17,7 @@
             <li><a href="about.html">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="portfolio.html" class="active">Portfolio</a></li>
-            <li><a href="#">Blog</a></li>
+            <li><a href="blog.html" class="active">Blog</a></li>
             <li><a href="contact.html">Contact</a></li>
         </ul>
     </nav>
@@ -110,4 +112,5 @@
         </div>
     </footer>
 </body>
+
 </html>

--- a/src/services.html
+++ b/src/services.html
@@ -17,7 +17,7 @@
             <li><a href="about.html" class="active">About</a></li>
             <li><a href="services.html">Services</a></li>
             <li><a href="portfolio.html">Portfolio</a></li>
-            <li><a href="#">Blog</a></li>
+            <li><a href="blog.html" class="active">Blog</a></li>
             <li><a href="contact.html">Contact</a></li>
         </ul>
     </nav>


### PR DESCRIPTION
This pull request includes updates to the navigation links across multiple HTML files to ensure the "Blog" link points to `blog.html` and is marked as active. Additionally, minor formatting changes have been made to the `portfolio.html` file.

Navigation link updates:

* [`src/about.html`](diffhunk://#diff-62ee5b5b6052f73e194bf260522c481f7dbfc2b5b329813eba1a7ca6b2ccbfd8L20-R20): Updated the "Blog" link to point to `blog.html` and marked it as active.
* [`src/contact.html`](diffhunk://#diff-3ce0b97af56466b85c42877e19819c3a74d34319632a79a4ed4fb30466a8c4e8L20-R20): Updated the "Blog" link to point to `blog.html` and marked it as active.
* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeL21-R21): Updated the "Blog" link to point to `blog.html` and marked it as active.
* [`src/services.html`](diffhunk://#diff-2baece2acfbb0944cdbd573df08e0c562a3be6acb1d86d00fe0e5efbb7e5aa09L20-R20): Updated the "Blog" link to point to `blog.html` and marked it as active.

